### PR TITLE
Add PHP 7.2 requirement at least and GitHub CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, zip, xml
+          coverage: none
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Update PHPUnit
+        run: composer update phpunit/phpunit --with-dependencies
+
+      - name: Run test suite
+        run: vendor/bin/phpunit

--- a/TestMore.php
+++ b/TestMore.php
@@ -181,7 +181,7 @@ function null_ok($e)
 function object_attribute_ok($o,$attributeName)
 {
     $test = get_testcase_object();
-    $test->assertNotNull($o, "object " . $o::class . " is not empty");
+    $test->assertNotNull($o, "object " . get_class($o) . " is not empty");
     $test->assertObjectHasAttribute($attributeName, $o);
 }
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
     "name": "corneltek\/phpunit-testmore",
     "require": {
-        "php": ">=8.2.3"
+        "php": ">=7.2.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.5 || ^8.5"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
# Changed log

- To be compatible with PHPBrew dependencies, it should require `php-7.2` version at least.
- Integrating the GitHub CI.
- To be compatible with `PHP 7.x` versions. using the `get_class` to get the class name.